### PR TITLE
Fix http request in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-	<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<link rel="stylesheet" type="text/css" href="css/main.css">
 </head>
 


### PR DESCRIPTION
If the website is accessed via HTTPS, the browser will complain about any requests made to http URLs. Google Fonts allows for both, so I changed it to always use the securer version.